### PR TITLE
Initial ioda-data repository

### DIFF
--- a/testinput_tier_1/Jason-2-2018-04-15.nc
+++ b/testinput_tier_1/Jason-2-2018-04-15.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dcf7781736fb35002532a07969e657b46e45e102823bf7b147f2e2f98edfb81
+size 1973688

--- a/testinput_tier_1/amsua_n15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/amsua_n15_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20113760ca5046c69064a9431161a1aab4f8ba173311664a589734090349d29
+size 122202

--- a/testinput_tier_1/amsua_n19_obs_2018041500_m.nc4
+++ b/testinput_tier_1/amsua_n19_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:579a6bfda7a0b06ad0bbb345c4c9c939c427812a50ab9a9938ea49f2ce48fc85
+size 122202

--- a/testinput_tier_1/aod_obs_2018041500_m.nc4
+++ b/testinput_tier_1/aod_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1499a4156bb13129b9d6ee3c2e77a55975c53f5bc0cddf0976466962f30587b
+size 22186

--- a/testinput_tier_1/aod_viirs_obs_2018041500_sf42.nc4
+++ b/testinput_tier_1/aod_viirs_obs_2018041500_sf42.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7b10142a8e8ef43aab3598a46a78b07604076e403cea6754e61fa5429c4123f
+size 18370

--- a/testinput_tier_1/cryosat2-2018-04-15.nc
+++ b/testinput_tier_1/cryosat2-2018-04-15.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7de300fd138e3b7fd90e3895f3a703779d58f88255193a15208a404e10b916b
+size 136873

--- a/testinput_tier_1/fileio.nc4
+++ b/testinput_tier_1/fileio.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b9a9829b235bdf7adc1e0e73538e897679641c037e28fe888b02964c8a60038
+size 12155

--- a/testinput_tier_1/geos_aod_obs_2018041500_m.nc4
+++ b/testinput_tier_1/geos_aod_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a773c27328c4476a68f65c2cee627a8cd1e917ae895a05778ae19f3589707c
+size 19969

--- a/testinput_tier_1/gmi_gpm_obs_2018041500_m.nc4
+++ b/testinput_tier_1/gmi_gpm_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3863c3fb8a825ba1746f87fa2541288c608998f8fe520bff223a374d9111c3e2
+size 162540

--- a/testinput_tier_1/icec-2018-04-15.nc
+++ b/testinput_tier_1/icec-2018-04-15.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2508edaadb6145631b98f90e2987810d3c8a5a60e5959622d6274b695296e923
+size 74214

--- a/testinput_tier_1/ioda_test_descending_sort.nc4
+++ b/testinput_tier_1/ioda_test_descending_sort.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3aace66b205a0c67b7a5e788e11fa788e76287cbb99d569cf2776973f02399e
+size 7959

--- a/testinput_tier_1/obsspace_grouping.nc4
+++ b/testinput_tier_1/obsspace_grouping.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b924e974ff40c7d01abf98d44443db2bbdbda5f78426d1a9c22aaf5faebe5b80
+size 13384

--- a/testinput_tier_1/obsspace_index_recnum.nc4
+++ b/testinput_tier_1/obsspace_index_recnum.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522c375d258d21fb65c376afdcd5386835271ca09de346cb03a89b27daa9757d
+size 7894

--- a/testinput_tier_1/profile_2018-04-15.nc
+++ b/testinput_tier_1/profile_2018-04-15.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e92b3aae8c63d170a7bea2856c3dbd9c4a55f01c6c5c301014f46298a3db5dff
+size 26769

--- a/testinput_tier_1/smap_obs_2018041500_m.nc4
+++ b/testinput_tier_1/smap_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:218584fda3386afef5a9325a749f03cbff4ef378b47150e87e2eda6c14141833
+size 88588

--- a/testinput_tier_1/sondes_obs_2018041500_m.nc4
+++ b/testinput_tier_1/sondes_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0d97c919af05f483ad29593ac7670f52a25f29c714e27f3d694bd44e286f3b2
+size 364737

--- a/testinput_tier_1/sondes_obs_2018041500_m_twfilt.nc4
+++ b/testinput_tier_1/sondes_obs_2018041500_m_twfilt.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acc9c0e1ac92e2d1a2e07072afc2503f658dbfeb6b812dff94d2f79860a7d48b
+size 347031

--- a/testinput_tier_1/sss_obs_20180415_m.nc4
+++ b/testinput_tier_1/sss_obs_20180415_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a76bc2676e0aa7733623534b8ab1fb2a008373e3237df29462e83ad5ede167b9
+size 23662

--- a/testinput_tier_1/sst_obs-2018-04-15.nc4
+++ b/testinput_tier_1/sst_obs-2018-04-15.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:559436c0416dfbfb9aa05c8723c593c2a69fea4bbd7d184ffa5fd33b5e827a99
+size 11600

--- a/testinput_tier_1/variable_assignment_testdata.nc
+++ b/testinput_tier_1/variable_assignment_testdata.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc937a80c1d4374dd597b5cfa3a606ea3eb44e5c109e18f1764ad613c99b65ae
+size 18866


### PR DESCRIPTION
## Description

This creates a new LFS-enabled to store and distribute the ioda tier 1 test data

### Issue(s) addressed

Link the issues to be closed with this PR
- partially fixes #https://github.com/jcsda-internal/ioda/issues/77

Note - I cannot assign this to an Epic or Milestone yet because these are not enabled for the repo.  I will enable them.  But, in any case, the Epic, Milestone, and Estimate are those for https://github.com/jcsda-internal/ioda/issues/77

## Acceptance Criteria (Definition of Done)

All ioda tier 1 tests pass using the new data management scheme.  

This is indeed achieved if I clone this repository into a directory with the following name:

```
<parent-directory>/ioda/develop
```
And then I set `LOCAL_PATH_JEDI_TESTFILES` to point to the `<parent-directory>`.  So, the tests will have to be modified to achieve this.


## Dependencies

None

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

- [ ] ioda

## Test Data

If this works as intended, then no test data needs to be updated on AWS S3.  The test data is located here instead.