### PR TITLE
adding cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+# (C) Copyright 2017-2020 UCAR.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+################################################################################
+# IODA Test Files
+################################################################################
+
+cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
+
+project( ioda_data VERSION 1.0.0 DESCRIPTION "IODA Test Files" )
+


### PR DESCRIPTION
## Description

This PR adds `CMakeLists.txt` to ioda-data repo so it can be cloned and built within bundles. 

### Issue(s) addressed
- partly https://github.com/JCSDA-internal/ioda/issues/71

## Acceptance Criteria (Definition of Done)

This is done when we can successfully clone ioda-data repo within bundles

## Dependencies

https://github.com/JCSDA-internal/ioda-bundle/pull/15 adds ioda-data to ioda-bundle
https://github.com/JCSDA-internal/ioda/pull/101 depends on this PR 

## Impact
none

## Test Data
none