### PR TITLE
minimum cmakelists.txt (#4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+# (C) Copyright 2017-2020 UCAR.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+################################################################################
+# IODA Test Files
+################################################################################
+
+cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
+
+project( ioda_data VERSION 1.0.0 DESCRIPTION "IODA Test Files" )
+


### PR DESCRIPTION
## Description

This merges @mer-a-o 's cmake changes into develop.  As I mentioned this morning, I do not think it is necessary to keep a separate ioda-v2 branch because the develop version of the code does not yet use ioda-data.  So, we can implement ioda-data together with the move to ioda v2.

### Issue(s) addressed

## Acceptance Criteria (Definition of Done)

Eliminate ioda-v2 branch and just have develop before renaming this repo to ioda-data-old

## Dependencies

None

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

- [ ] ioda
- [ ] ioda-bundle

## Test Data
